### PR TITLE
Implement UCSBSubjectController GET and POST methods

### DIFF
--- a/src/main/java/edu/ucsb/cs156/team02/controllers/UCSBSubjectController.java
+++ b/src/main/java/edu/ucsb/cs156/team02/controllers/UCSBSubjectController.java
@@ -67,10 +67,8 @@ public class UCSBSubjectController extends ApiController {
             @ApiParam("inactive") @RequestParam Boolean inactive,
             @ApiParam("done") @RequestParam Boolean done) {
         loggingService.logMethod();
-        CurrentUser currentUser = getCurrentUser();
 
         UCSBSubject subject = new UCSBSubject();
-        subject.setUser(currentUser.getUser());
         subject.setSubjectCode(subjectCode);
         subject.setSubjectTranslation(subjectTranslation);
         subject.setDeptCode(deptCode);

--- a/src/main/java/edu/ucsb/cs156/team02/controllers/UCSBSubjectController.java
+++ b/src/main/java/edu/ucsb/cs156/team02/controllers/UCSBSubjectController.java
@@ -30,16 +30,18 @@ public class UCSBSubjectController extends ApiController {
      * whether subjects exist, and whether they belong to the current user,
      * along with the error messages pertaining to those situations. It
      * bundles together the state needed for those checks.
-     */
-    public class UCSBSubjectOrError {
-        Long id;
-        UCSBSubject subject;
-        ResponseEntity<String> error;
-
-        public UCSBSubjectOrError(Long id) {
-            this.id = id;
-        }
-    }
+     *
+     * Don't need yet because we haven't written these methods
+     * /
+//    public class UCSBSubjectOrError {
+//        Long id;
+//        UCSBSubject subject;
+//        ResponseEntity<String> error;
+//
+//        public UCSBSubjectOrError(Long id) {
+//            this.id = id;
+//        }
+//    }
 
     @Autowired
     UCSBSubjectRepository subjectRepository;

--- a/src/main/java/edu/ucsb/cs156/team02/controllers/UCSBSubjectController.java
+++ b/src/main/java/edu/ucsb/cs156/team02/controllers/UCSBSubjectController.java
@@ -1,7 +1,6 @@
 package edu.ucsb.cs156.team02.controllers;
 
 import edu.ucsb.cs156.team02.entities.UCSBSubject;
-import edu.ucsb.cs156.team02.entities.User;
 import edu.ucsb.cs156.team02.models.CurrentUser;
 import edu.ucsb.cs156.team02.repositories.UCSBSubjectRepository;
 import io.swagger.annotations.Api;
@@ -9,23 +8,16 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import lombok.extern.slf4j.Slf4j;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import javax.validation.Valid;
-import java.util.Optional;
 
 @Api(description = "UCSBSubjects")
 @RequestMapping("/api/UCSBSubjects")
@@ -56,9 +48,37 @@ public class UCSBSubjectController extends ApiController {
     ObjectMapper mapper;
 
     @ApiOperation(value = "List all subjects")
+    @PreAuthorize("hasRole('ROLE_USER')")
     @GetMapping("/all")
     public Iterable<UCSBSubject> allSubjects() {
         loggingService.logMethod();
         return subjectRepository.findAll();
+    }
+
+    @ApiOperation(value = "Create a new UCSBSubject")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @PostMapping("/post")
+    public UCSBSubject postSubject(
+            @ApiParam("subject code") @RequestParam String subjectCode,
+            @ApiParam("subject translation") @RequestParam String subjectTranslation,
+            @ApiParam("department code") @RequestParam String deptCode,
+            @ApiParam("college code") @RequestParam String collegeCode,
+            @ApiParam("related department code") @RequestParam String relatedDeptCode,
+            @ApiParam("inactive") @RequestParam Boolean inactive,
+            @ApiParam("done") @RequestParam Boolean done) {
+        loggingService.logMethod();
+        CurrentUser currentUser = getCurrentUser();
+
+        UCSBSubject subject = new UCSBSubject();
+        subject.setUser(currentUser.getUser());
+        subject.setSubjectCode(subjectCode);
+        subject.setSubjectTranslation(subjectTranslation);
+        subject.setDeptCode(deptCode);
+        subject.setCollegeCode(collegeCode);
+        subject.setRelatedDeptCode(relatedDeptCode);
+        subject.setInactive(inactive);
+        subject.setDone(done);
+
+        return subjectRepository.save(subject);
     }
 }

--- a/src/main/java/edu/ucsb/cs156/team02/controllers/UCSBSubjectController.java
+++ b/src/main/java/edu/ucsb/cs156/team02/controllers/UCSBSubjectController.java
@@ -1,0 +1,64 @@
+package edu.ucsb.cs156.team02.controllers;
+
+import edu.ucsb.cs156.team02.entities.UCSBSubject;
+import edu.ucsb.cs156.team02.entities.User;
+import edu.ucsb.cs156.team02.models.CurrentUser;
+import edu.ucsb.cs156.team02.repositories.UCSBSubjectRepository;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import lombok.extern.slf4j.Slf4j;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+import java.util.Optional;
+
+@Api(description = "UCSBSubjects")
+@RequestMapping("/api/UCSBSubjects")
+@RestController
+@Slf4j
+public class UCSBSubjectController extends ApiController {
+
+    /**
+     * This inner class helps us factor out some code for checking
+     * whether subjects exist, and whether they belong to the current user,
+     * along with the error messages pertaining to those situations. It
+     * bundles together the state needed for those checks.
+     */
+    public class UCSBSubjectOrError {
+        Long id;
+        UCSBSubject subject;
+        ResponseEntity<String> error;
+
+        public UCSBSubjectOrError(Long id) {
+            this.id = id;
+        }
+    }
+
+    @Autowired
+    UCSBSubjectRepository subjectRepository;
+
+    @Autowired
+    ObjectMapper mapper;
+
+    @ApiOperation(value = "List all subjects")
+    @GetMapping("/all")
+    public Iterable<UCSBSubject> allSubjects() {
+        loggingService.logMethod();
+        return subjectRepository.findAll();
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/team02/controllers/UCSBSubjectController.java
+++ b/src/main/java/edu/ucsb/cs156/team02/controllers/UCSBSubjectController.java
@@ -32,7 +32,7 @@ public class UCSBSubjectController extends ApiController {
      * bundles together the state needed for those checks.
      *
      * Don't need yet because we haven't written these methods
-     * /
+     */
 //    public class UCSBSubjectOrError {
 //        Long id;
 //        UCSBSubject subject;

--- a/src/main/java/edu/ucsb/cs156/team02/controllers/UCSBSubjectController.java
+++ b/src/main/java/edu/ucsb/cs156/team02/controllers/UCSBSubjectController.java
@@ -64,8 +64,8 @@ public class UCSBSubjectController extends ApiController {
             @ApiParam("department code") @RequestParam String deptCode,
             @ApiParam("college code") @RequestParam String collegeCode,
             @ApiParam("related department code") @RequestParam String relatedDeptCode,
-            @ApiParam("inactive") @RequestParam Boolean inactive,
-            @ApiParam("done") @RequestParam Boolean done) {
+            @ApiParam("inactive") @RequestParam Boolean inactive)
+            {
         loggingService.logMethod();
 
         UCSBSubject subject = new UCSBSubject();
@@ -75,7 +75,6 @@ public class UCSBSubjectController extends ApiController {
         subject.setCollegeCode(collegeCode);
         subject.setRelatedDeptCode(relatedDeptCode);
         subject.setInactive(inactive);
-        subject.setDone(done);
 
         return subjectRepository.save(subject);
     }

--- a/src/main/java/edu/ucsb/cs156/team02/entities/UCSBSubject.java
+++ b/src/main/java/edu/ucsb/cs156/team02/entities/UCSBSubject.java
@@ -16,7 +16,7 @@ import lombok.Builder;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-@Entity(name = "ucsb_subects")
+@Entity(name = "ucsb_subjects")
 public class UCSBSubject {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/edu/ucsb/cs156/team02/entities/UCSBSubject.java
+++ b/src/main/java/edu/ucsb/cs156/team02/entities/UCSBSubject.java
@@ -33,6 +33,5 @@ public class UCSBSubject {
     private String collegeCode;
     private String relatedDeptCode;
     private boolean inactive;
-    private boolean done;
 
 }

--- a/src/main/java/edu/ucsb/cs156/team02/entities/UCSBSubject.java
+++ b/src/main/java/edu/ucsb/cs156/team02/entities/UCSBSubject.java
@@ -35,8 +35,4 @@ public class UCSBSubject {
     private boolean inactive;
     private boolean done;
 
-    @ManyToOne
-    @JoinColumn(name = "user_id")
-    private User user;
-
 }

--- a/src/test/java/edu/ucsb/cs156/team02/controllers/UCSBSubjectControllerTest.java
+++ b/src/test/java/edu/ucsb/cs156/team02/controllers/UCSBSubjectControllerTest.java
@@ -74,8 +74,7 @@ class UCSBSubjectControllerTest extends ControllerTestCase {
         UCSBSubject subject2 = UCSBSubject.builder().subjectCode("Subject 2").subjectTranslation("Translation 2").deptCode("Dept code 2").collegeCode("College code 2").relatedDeptCode("Related dept code 2").inactive(false).id(1L).build();
         UCSBSubject subject3 = UCSBSubject.builder().subjectCode("Subject 3").subjectTranslation("Translation 3").deptCode("Dept code 3").collegeCode("College code 3").relatedDeptCode("Related dept code 3").inactive(false).id(1L).build();
 
-        ArrayList<UCSBSubject> expectedSubjects = new ArrayList<>();
-        expectedSubjects.addAll(Arrays.asList(subject1, subject2, subject3));
+        ArrayList<UCSBSubject> expectedSubjects = new ArrayList<>(Arrays.asList(subject1, subject2, subject3));
 
         when(subjectRepository.findAll()).thenReturn(expectedSubjects);
 

--- a/src/test/java/edu/ucsb/cs156/team02/controllers/UCSBSubjectControllerTest.java
+++ b/src/test/java/edu/ucsb/cs156/team02/controllers/UCSBSubjectControllerTest.java
@@ -1,0 +1,123 @@
+package edu.ucsb.cs156.team02.controllers;
+
+import edu.ucsb.cs156.team02.entities.Todo;
+import edu.ucsb.cs156.team02.repositories.TodoRepository;
+import edu.ucsb.cs156.team02.repositories.UserRepository;
+import edu.ucsb.cs156.team02.testconfig.TestConfig;
+import edu.ucsb.cs156.team02.ControllerTestCase;
+import edu.ucsb.cs156.team02.entities.UCSBSubject;
+import edu.ucsb.cs156.team02.entities.User;
+import edu.ucsb.cs156.team02.repositories.UCSBSubjectRepository;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Optional;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(controllers = UCSBSubjectController.class)
+@Import(TestConfig.class)
+class UCSBSubjectControllerTest extends ControllerTestCase {
+
+    @MockBean
+    UCSBSubjectRepository subjectRepository;
+
+    @MockBean
+    UserRepository userRepository;
+
+    // Authorization tests for /api/UCSBSubjects/all
+
+    @Test
+    public void api_UCSBSubjects_all__logged_out__returns_403() throws Exception {
+        mockMvc.perform(get("/api/UCSBSubjects/all"))
+                .andExpect(status().is(403));
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void api_UCSBSubjects_all__user_logged_in__returns_200() throws Exception {
+        mockMvc.perform(get("/api/UCSBSubjects/all"))
+                .andExpect(status().isOk());
+    }
+
+    // Authorization tests for /api/UCSBSubjects/post
+
+    @Test
+    public void api_UCSBSubjects_post__logged_out__returns_403() throws Exception {
+        mockMvc.perform(post("/api/UCSBSubjects/post"))
+                .andExpect(status().is(403));
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void api_UCSBSubjects_all__user_logged_in__returns_all_subjects() throws Exception {
+
+        // arrange
+
+        UCSBSubject subject1 = UCSBSubject.builder().subjectCode("Subject 1").subjectTranslation("Translation 1").deptCode("Dept code 1").collegeCode("College code 1").relatedDeptCode("Related dept code 1").inactive(false).id(1L).build();
+        UCSBSubject subject2 = UCSBSubject.builder().subjectCode("Subject 2").subjectTranslation("Translation 2").deptCode("Dept code 2").collegeCode("College code 2").relatedDeptCode("Related dept code 2").inactive(false).id(1L).build();
+        UCSBSubject subject3 = UCSBSubject.builder().subjectCode("Subject 3").subjectTranslation("Translation 3").deptCode("Dept code 3").collegeCode("College code 3").relatedDeptCode("Related dept code 3").inactive(false).id(1L).build();
+
+        ArrayList<UCSBSubject> expectedSubjects = new ArrayList<>();
+        expectedSubjects.addAll(Arrays.asList(subject1, subject2, subject3));
+
+        when(subjectRepository.findAll()).thenReturn(expectedSubjects);
+
+        // act
+        MvcResult response = mockMvc.perform(get("/api/UCSBSubjects/all"))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+
+        verify(subjectRepository, times(1)).findAll();
+        String expectedJson = mapper.writeValueAsString(expectedSubjects);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void api_UCSBSubjects_post__user_logged_in() throws Exception {
+        // arrange
+
+        UCSBSubject expectedSubject = UCSBSubject.builder()
+                .subjectCode("Test Code")
+                .subjectTranslation("Test Translation")
+                .deptCode("Test dept code")
+                .collegeCode("Test college code")
+                .relatedDeptCode("Related dept code")
+                .inactive(false)
+                .id(0L)
+                .build();
+
+        when(subjectRepository.save(eq(expectedSubject))).thenReturn(expectedSubject);
+
+        // act
+        MvcResult response = mockMvc.perform(
+                        post("/api/UCSBSubjects/post?subjectCode=Test Code&subjectTranslation=Test Translation&deptCode=Test dept code&collegeCode=Test college code&relatedDeptCode=Related dept code&inactive=false")
+                                .with(csrf()))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(subjectRepository, times(1)).save(expectedSubject);
+        String expectedJson = mapper.writeValueAsString(expectedSubject);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
+}


### PR DESCRIPTION
This pr adds the ability for users to create and view subjects in the database. It implements 2 API endpoints: `/api/UCSBSubjects/all` and `api/UCSBSubjects/post`, which can be used to perform said actions:
<img width="1477" alt="image" src="https://user-images.githubusercontent.com/59625987/152875821-15eaba08-c384-4215-a429-07754bd68551.png">
