### PR TITLE
UCSB Subjects GET and PUT by ID

### DIFF
--- a/src/main/java/edu/ucsb/cs156/team02/controllers/UCSBSubjectController.java
+++ b/src/main/java/edu/ucsb/cs156/team02/controllers/UCSBSubjectController.java
@@ -1,5 +1,6 @@
 package edu.ucsb.cs156.team02.controllers;
 
+import edu.ucsb.cs156.team02.entities.Todo;
 import edu.ucsb.cs156.team02.entities.UCSBSubject;
 import edu.ucsb.cs156.team02.entities.User;
 import edu.ucsb.cs156.team02.models.CurrentUser;
@@ -66,6 +67,24 @@ public class UCSBSubjectController extends ApiController {
         return subjectRepository.findAll();
     }
 
+    @ApiOperation(value = "Get a single subject")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public ResponseEntity<String> getSubjectByID(
+            @ApiParam("id") @RequestParam Long id) throws JsonProcessingException {
+        loggingService.logMethod();
+
+        UCSBSubjectController.UCSBSubjectOrError soe = new UCSBSubjectController.UCSBSubjectOrError(id);
+
+        soe = doesSubjectExist(soe);
+        if (soe.error != null) {
+            return soe.error;
+        }
+
+        String body = mapper.writeValueAsString(soe.subject);
+        return ResponseEntity.ok().body(body);
+    }
+
     @ApiOperation(value = "Create a new UCSBSubject")
     @PreAuthorize("hasRole('ROLE_USER')")
     @PostMapping("/post")
@@ -108,6 +127,33 @@ public class UCSBSubjectController extends ApiController {
 
         return ResponseEntity.ok().body(String.format("subject with id %d deleted", id));
 
+    }
+
+    @ApiOperation(value = "Update a single subject")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @PutMapping("")
+    public ResponseEntity<String> putSubjectById(
+            @ApiParam("id") @RequestParam Long id,
+            @RequestBody @Valid UCSBSubject incomingSubject) throws JsonProcessingException {
+        loggingService.logMethod();
+
+        UCSBSubjectOrError soe = new UCSBSubjectOrError(id);
+
+        soe = doesSubjectExist(soe);
+        if (soe.error != null) {
+            return soe.error;
+        }
+        soe = doesSubjectExist(soe);
+        if (soe.error != null) {
+            return soe.error;
+        }
+
+        incomingSubject.setId(id);
+
+        subjectRepository.save(incomingSubject);
+
+        String body = mapper.writeValueAsString(incomingSubject);
+        return ResponseEntity.ok().body(body);
     }
 
     public UCSBSubjectOrError doesSubjectExist(UCSBSubjectOrError soe) {

--- a/src/main/java/edu/ucsb/cs156/team02/controllers/UCSBSubjectController.java
+++ b/src/main/java/edu/ucsb/cs156/team02/controllers/UCSBSubjectController.java
@@ -143,12 +143,6 @@ public class UCSBSubjectController extends ApiController {
         if (soe.error != null) {
             return soe.error;
         }
-        soe = doesSubjectExist(soe);
-        if (soe.error != null) {
-            return soe.error;
-        }
-
-        incomingSubject.setId(id);
 
         subjectRepository.save(incomingSubject);
 

--- a/src/test/java/edu/ucsb/cs156/team02/controllers/UCSBSubjectControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/team02/controllers/UCSBSubjectControllerTests.java
@@ -175,4 +175,52 @@ class UCSBSubjectControllerTests extends ControllerTestCase {
         String responseString = response.getResponse().getContentAsString();
         assertEquals("subject with id 16 not found", responseString);
     }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void api_subjects__user_logged_in__search_for_subject_that_exists() throws Exception {
+
+        // arrange
+
+        UCSBSubject otherUsersSubject = UCSBSubject.builder().subjectCode("Test Code")
+                .subjectTranslation("Test Translation")
+                .deptCode("Test dept code")
+                .collegeCode("Test college code")
+                .relatedDeptCode("Related dept code")
+                .inactive(false)
+                .id(27L)
+                .build();
+
+        when(subjectRepository.findById(eq(27L))).thenReturn(Optional.of(otherUsersSubject));
+
+        // act
+        MvcResult response = mockMvc.perform(get("/api/UCSBSubjects?id=27"))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+
+        verify(subjectRepository, times(1)).findById(eq(27L));
+        String expectedJson = mapper.writeValueAsString(otherUsersSubject);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void api_subjects__user_logged_in__search_for_subject_that_does_not_exist() throws Exception {
+
+        // arrange
+
+        when(subjectRepository.findById(eq(29L))).thenReturn(Optional.empty());
+
+        // act
+        MvcResult response = mockMvc.perform(get("/api/UCSBSubjects?id=29"))
+                .andExpect(status().isBadRequest()).andReturn();
+
+        // assert
+
+        verify(subjectRepository, times(1)).findById(eq(29L));
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals("subject with id 29 not found", responseString);
+    }
 }

--- a/src/test/java/edu/ucsb/cs156/team02/controllers/UCSBSubjectControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/team02/controllers/UCSBSubjectControllerTests.java
@@ -1,19 +1,15 @@
 package edu.ucsb.cs156.team02.controllers;
 
-import edu.ucsb.cs156.team02.entities.Todo;
-import edu.ucsb.cs156.team02.repositories.TodoRepository;
 import edu.ucsb.cs156.team02.repositories.UserRepository;
 import edu.ucsb.cs156.team02.testconfig.TestConfig;
 import edu.ucsb.cs156.team02.ControllerTestCase;
 import edu.ucsb.cs156.team02.entities.UCSBSubject;
-import edu.ucsb.cs156.team02.entities.User;
 import edu.ucsb.cs156.team02.repositories.UCSBSubjectRepository;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
-import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MvcResult;
 
@@ -33,7 +29,7 @@ import static org.mockito.Mockito.when;
 
 @WebMvcTest(controllers = UCSBSubjectController.class)
 @Import(TestConfig.class)
-class UCSBSubjectControllerTest extends ControllerTestCase {
+class UCSBSubjectControllerTests extends ControllerTestCase {
 
     @MockBean
     UCSBSubjectRepository subjectRepository;


### PR DESCRIPTION
Closes #18 and #19 -- adds endpoints to edit and query specific subjects by their ID in the database:

<img width="1438" alt="image" src="https://user-images.githubusercontent.com/59625987/153144689-fb443303-2f38-4e9d-b07d-05256f53cc29.png">

